### PR TITLE
feat: extended control-payload to add Args for streaming support

### DIFF
--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -3,6 +3,7 @@ package file
 import (
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 )
@@ -11,22 +12,23 @@ type File struct {
 	BasePath string
 	KeyPath  string
 	FileMode os.FileMode
-	fileSize int64
+	FileSize int64
 }
 
 // WriteStream writes into the File f from io.Reader r
 func (f *File) WriteStream(r io.Reader) error {
 	fd, err := f.openFileForWriting()
 	if err != nil {
-		fmt.Println("File Error: Couldn't create file descriptor for writing", err)
+		log.Printf("File Error: Couldn't create file descriptor for writing: %+v", err)
 		return err
 	}
 	n, err := io.Copy(fd, r)
 	if err != nil {
-		fmt.Println("File Error: Error writing contents into file descriptor", err)
+		log.Printf("File Error: Error writing contents into file descriptor: %+v", err)
 		return err
 	}
-	f.fileSize = n
+	f.FileSize = n
+	log.Printf("Written %d bytes to %s/%s", f.FileSize, f.BasePath, f.KeyPath)
 	return nil
 }
 
@@ -61,7 +63,6 @@ func (f *File) openFileForWriting() (*os.File, error) {
 		return nil, err
 	}
 	fullPath := fmt.Sprintf("%s/%s", f.BasePath, f.KeyPath)
-	fmt.Printf("File will be written to %s\n", fullPath)
 	return os.Create(fullPath)
 }
 

--- a/internal/p2p/message.go
+++ b/internal/p2p/message.go
@@ -38,7 +38,7 @@ type DataPayload struct {
 // ControlPayload represents control messages
 type ControlPayload struct {
 	Command ControlMessage
-	//Args    map[string]string
+	Args    map[string]string
 }
 
 type Message struct {
@@ -66,7 +66,8 @@ func ParseMessage(msg Message) *Message {
 
 // ParseControlMessage handles parsing of control payloads into decodedMsg
 func ParseControlMessage(msg Message, decodedMsg *Message) *Message {
-	decodedMsg.Payload = ControlPayload{Command: msg.Payload.(ControlPayload).Command}
+	controlPayload := msg.Payload.(ControlPayload)
+	decodedMsg.Payload = controlPayload
 	return decodedMsg
 }
 

--- a/internal/util/constants.go
+++ b/internal/util/constants.go
@@ -8,9 +8,10 @@ import (
 
 // Default File instance opts
 const (
-	DefaultFileContent  = "some png bytes"
-	DefaultFileKeyPath  = "TestKeyPath"
-	DefaultFileBasePath = "TestBasePath"
+	DefaultFileContent      = "some png bytes"
+	DefaultLargeFileContent = "\n\nLorem ipsum dolor sit amet, consectetur adipiscing elit. In bibendum ipsum et arcu placerat, sit amet scelerisque dui tempor. Nunc ligula nulla, faucibus vulputate laoreet vel, ultricies nec justo. Sed volutpat lorem enim, vel imperdiet velit fringilla non. Donec nec nibh libero. Integer non dui dictum lorem semper interdum. Duis et finibus leo. Curabitur pellentesque, erat sed vestibulum elementum, augue ex vehicula quam, ac dictum lectus sem vel odio. In vitae pharetra est. Vestibulum venenatis tortor et placerat aliquet. Aenean interdum nisl at pulvinar congue. Sed odio diam, aliquam non urna ac, commodo sollicitudin elit. Sed eu purus ultrices tortor iaculis vestibulum. Vivamus vitae mi laoreet nulla faucibus pharetra. Mauris posuere sit amet dolor quis eleifend. Nunc odio nisi, accumsan non justo non, volutpat vulputate nisi. Donec sapien nisi, molestie quis augue ac, condimentum rutrum orci.\n\nEtiam condimentum, orci a euismod maximus, tortor ipsum scelerisque leo, vitae condimentum arcu risus at sem. In ut tellus eros. In elit nunc, volutpat auctor sollicitudin quis, pretium eu est. Vivamus rhoncus hendrerit neque, et ultrices mauris. Cras sollicitudin, elit sit amet interdum efficitur, arcu massa porta turpis, nec efficitur tellus nisl sed neque. Nulla vel elit felis. Maecenas eu tellus ut enim porttitor laoreet vitae non ligula.\n\nPellentesque nulla eros, finibus a nunc id, varius porta erat. Integer vestibulum eleifend ipsum in pharetra. Suspendisse potenti. Nulla ut dui libero. Phasellus scelerisque vestibulum ex vel lacinia. Proin nec tellus at orci feugiat facilisis eget eu est. Mauris sed enim ac lorem eleifend ullamcorper. Fusce vel tortor mattis massa mattis pretium.\n\nNulla feugiat vulputate leo. Nunc condimentum nibh vitae lorem placerat commodo. Cras luctus libero nec dolor luctus ornare. Quisque vitae nisi id libero bibendum convallis. Ut sit amet augue risus. Praesent at pretium purus. Pellentesque tincidunt non mi at posuere. Vivamus ullamcorper, nulla a lacinia sodales, dui leo bibendum augue justo.\n"
+	DefaultFileKeyPath      = "TestKeyPath"
+	DefaultFileBasePath     = "TestBasePath"
 )
 
 // File permission octal constants
@@ -51,8 +52,9 @@ const (
 // --------------------------------------------------------------  P2P CONSTANTS --------------------------------------------------------------
 
 const (
-	DefaultChunkSize      uint8 = 10
-	MessageChanBufferSize       = 32
+	DefaultChunkSize          uint8 = 10
+	MessageChanBufferSize           = 32
+	MaxAllowedDataPayloadSize       = 1024
 )
 
 // --------------------------------------------------------------  END OF P2P CONSTANTS --------------------------------------------------------------

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ func initStore(commandLineArgs util.CommandLineArgs) {
 	if commandLineArgs.TestStorage {
 		log.Println("Basic storage FT")
 		time.Sleep(time.Second * 2)
-		data := bytes.NewReader([]byte("some random bytes to store"))
+		data := bytes.NewReader([]byte(util.DefaultLargeFileContent))
 		err := globalStore.handleStoreFile("test_key", data)
 		if err != nil {
 			log.Fatalf("Error while writing test file -> %+v", err)
@@ -34,6 +34,10 @@ func initStore(commandLineArgs util.CommandLineArgs) {
 			Type: p2p.ControlMessageType,
 			Payload: p2p.ControlPayload{
 				Command: p2p.MESSAGE_STORE_CONTROL_COMMAND,
+				Args: map[string]string{
+					"key":  "test_key",
+					"size": "6",
+				},
 			},
 		}
 		if err = globalStore.broadcastMessage(msg); err != nil {

--- a/storage_test.go
+++ b/storage_test.go
@@ -42,8 +42,9 @@ func TestContentAddressableTransformFunc(t *testing.T) {
 func TestUploadFile(t *testing.T) {
 	store := getStoreInstance(":5000", []string{":6000"}, "")
 	data := []byte(util.CommonStringContent)
-	err := store.handleFileWrite(util.CommonFileKey, bytes.NewReader(data))
+	fileSize, err := store.handleFileWrite(util.CommonFileKey, bytes.NewReader(data))
 	assert.Nil(t, err)
+	assert.NotZero(t, fileSize)
 }
 
 func TestReadFile(t *testing.T) {


### PR DESCRIPTION
Added Args field in ControlPayload to allow passing other metadata along with Control Messages for extended support
Added basic support for streaming by adding a check for large files and sending a control message instead of DataPayload in such cases 